### PR TITLE
improve card id display

### DIFF
--- a/src/scrummer.css
+++ b/src/scrummer.css
@@ -74,6 +74,11 @@ textarea.mod-list-name.list-header-name {
   display: inline;
 }
 
-.scrummer-card-id::after {
-  content: ' ';
+.scrummer-card-id {
+  background-color: #ffdd00;
+  border: 1px solid #ffdd00;
+  margin-right: 3px;
+  padding: 0px 3px;
+  border-radius: 5px;
 }
+


### PR DESCRIPTION
<img width="254" alt="screen shot 2018-07-10 at 12 21 43" src="https://user-images.githubusercontent.com/8972446/42504445-1eb7bc22-843c-11e8-82f1-4eb08e72c20e.png">

Je voulais retrouver l'apparence des ID de carte de la feuille stylish, qu'on ne peut plus utiliser now.
